### PR TITLE
Add optional prefix stripping for resulting output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        python_version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+      - run: pip install pytest
+      - run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ plugins:
 To include a portion of a file use
 
 ```
-{{include_with_anchor('<file-name>', '<anchor name>')}}
+{{include_with_anchor('<file-name>', '<anchor name>'[, strip_prefix='<optional prefix>'])}}
 ```
+
+> [!TIP]
+> `strip_prefix` is an optional parameter that can strip a prefix from each line of the resulting content. This is
+> useful if, for example, you have indented content that you wish to present unindented.
 
 ## Example
 
@@ -79,7 +83,6 @@ Example: Include selected lines.
 Example: Include all lines.
 
 {{include_with_anchor('inc.txt', 'begin')}}
-
 ```
 
 After running mkdocs build, the resulting page would look like
@@ -96,5 +99,4 @@ Example: Include all lines.
 2. Item 2
 3. Item 3
 4. Item 4
-
 ```

--- a/mkdocs_pluglet_file_include/__init__.py
+++ b/mkdocs_pluglet_file_include/__init__.py
@@ -4,30 +4,37 @@ import re
 ANCHOR_START = r"ANCHOR:\s*(?P<anchor_name>[\w_-]+)"
 ANCHOR_END = r"ANCHOR_END:\s*(?P<anchor_name>[\w_-]+)"
 
+
+def _find_content(file_lines, anchor_id, remove_prefix=None):
+    anchor_found = False
+    saved_content = []
+
+    for l in file_lines:
+        match re.search(ANCHOR_START, l):
+            case None:
+                match re.search(ANCHOR_END, l):
+                    case None:
+                        if anchor_found:
+                            saved_content.append(
+                                l.removeprefix(remove_prefix) if remove_prefix else l
+                            )
+                    case x:
+                        anchor = m.group(0)
+                        anchor_value = anchor.split(": ")[1]
+                        if anchor_value == anchor_id:
+                            break
+            case m:
+                anchor = m.group(0)
+                anchor_value = anchor.split(": ")[1]
+                if anchor_value == anchor_id:
+                    anchor_found = True
+    return "\n".join(saved_content)
+
+
 def define_env(env):
     @env.macro
-    def include_with_anchor(fname, anchor_id):
+    def include_with_anchor(fname, anchor_id, remove_prefix=None):
         with open(fname) as f:
             data = f.read()
 
-        anchor_found = False
-        saved_content = []
-
-        for l in data.split('\n'):
-            match re.search(ANCHOR_START, l):
-                case None:
-                    match re.search(ANCHOR_END, l):
-                        case None:
-                            if anchor_found:
-                                saved_content.append(l)
-                        case x:
-                            anchor = m.group(0)
-                            anchor_value = anchor.split(': ')[1]
-                            if anchor_value == anchor_id:
-                                break
-                case m: 
-                    anchor = m.group(0)
-                    anchor_value = anchor.split(': ')[1]
-                    if anchor_value == anchor_id:
-                        anchor_found = True
-        return '\n'.join(saved_content)
+        return _find_content(data.split("\n"), anchor_id, remove_prefix)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mkdocs-pluglet-file-include',
-    version='0.1.0',
+    version='0.1.1',
     description="include file contents using anchors",
     packages=['mkdocs_pluglet_file_include'],
     license='GPL3',

--- a/test/test_include_with_anchor.py
+++ b/test/test_include_with_anchor.py
@@ -1,0 +1,59 @@
+import pytest
+import mkdocs_pluglet_file_include
+
+
+def test_basic_usage():
+    assert (
+        mkdocs_pluglet_file_include._find_content(
+            ["# ANCHOR: test", "content", "# ANCHOR_END: test"], anchor_id="test"
+        )
+        == "content"
+    )
+
+
+def test_basic_multi_line_usage():
+    assert (
+        mkdocs_pluglet_file_include._find_content(
+            ["# ANCHOR: test", "content", "more", "# ANCHOR_END: test"],
+            anchor_id="test",
+        )
+        == "content\nmore"
+    )
+
+
+def test_basic_multi_anchor():
+    assert mkdocs_pluglet_file_include._find_content(
+        [
+            "# ANCHOR: test",
+            "# ANCHOR: another_test",
+            "content",
+            "# ANCHOR_END: another_test",
+            "outside_content",
+            "# ANCHOR_END: test",
+        ],
+        anchor_id="test",
+    ) == "\n".join(["content", "outside_content"])
+
+
+def test_stripping_lines():
+    assert (
+        mkdocs_pluglet_file_include._find_content(
+            ["# ANCHOR: test", "  content", "# ANCHOR_END: test"],
+            anchor_id="test",
+            remove_prefix="  ",
+        )
+        == "content"
+    )
+
+
+def test_stripping_mutilple_lines():
+    assert mkdocs_pluglet_file_include._find_content(
+        [
+            "# ANCHOR: test",
+            "  indented: yes",
+            "    content: true",
+            "# ANCHOR_END: test",
+        ],
+        anchor_id="test",
+        remove_prefix="  ",
+    ) == "\n".join(["indented: yes", "  content: true"])


### PR DESCRIPTION
Add an optional parameter that allows stripping a prefix from each line of the resulting output. As the parameter is optional, this is backwards compatible with the existing API.

Additionally:

* Add tests
* Add note to README regarding the new parameter.
* Bump version in setup.py
* Add CI for GH actions